### PR TITLE
fixed string serialization in case of a string longer than 1024

### DIFF
--- a/MsgPack.Runtime/MsgPackStream.cs
+++ b/MsgPack.Runtime/MsgPackStream.cs
@@ -251,11 +251,10 @@ namespace Pixonic.MsgPack
         public void WriteString(string value)
         {
             var length = value.Length;
-            var maxChunkSize = Utf8.GetMaxCharCount(ChunkSize);
 
             for (var offset = 0; length > 0;)
             {
-                var chunkSize = length > maxChunkSize ? maxChunkSize : length;
+                var chunkSize = length > ChunkSize ? ChunkSize : length;
                 var bytesCount = Utf8.GetBytes(value, offset, chunkSize, _tempBuffer, 0);
 
                 Flush(_tempBuffer, 0, bytesCount);


### PR DESCRIPTION
 Utf8.GetMaxCharCount(1024) возвращал 1025, что не лезло в буффер.